### PR TITLE
Add documentation for can-vdom APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,5 @@ node_modules
 # Users Environment Variables
 .lock-wscript
 
-docs/
+doc/
 dist/

--- a/README.md
+++ b/README.md
@@ -4,55 +4,115 @@
 
 A browser-lite environment for nodejs
 
-## Usage
+- <code>[__can-vdom__ Object](#can-vdom-object)</code>
+  - _modules_
+    - <code>[__can-vdom/make-window/make-window__ function](#can-vdommake-windowmake-window-function)</code>
+      - <code>[makeWindow()](#makewindow)</code>
+      - <code>[makeWindow(global)](#makewindowglobal)</code>
+    - <code>[__can-vdom/make-document/make-document__ function](#can-vdommake-documentmake-document-function)</code>
+      - <code>[makeDocument()](#makedocument)</code>
+  - _types_
+    - <code>[window Object](#window-object)</code>
 
-### ES6 use
+## API
 
-With StealJS, you can import this module directly in a template that is autorendered:
+##  `{Object}`
+
+ 
+A browser-lite environment for Node.js.
 
 ```js
-import plugin from 'can-vdom';
+require("can-vdom");
+
+window === global; // true
+
+document.getElementsByTagName("body"); // [HTMLBodyElement]
 ```
 
-### CommonJS use
 
-Use `require` to load `can-vdom` and everything else
-needed to create a template that uses `can-vdom`:
+
+
+### <code>Object</code>
+
+
+### <code>__can-vdom/make-window/make-window__ function</code>
+
+Exports a function that window called, returns an object that looks like a `window`.
+
+
+#### <code>makeWindow()</code>
+
+
+Creates a document and places it, along with other common browser globals, on a new object and then returns that object.
+
+
+- __returns__ <code>{[window](#window-object)}</code>:
+  An object with common browser globals.
+  
+
+#### <code>makeWindow(global)</code>
+
+
+Creates a document and places it, along with other common browser globals, on the `global` object.
 
 ```js
-var plugin = require("can-vdom");
+var makeWindow = require("can-vdom/make-window/make-window");
+
+var window = makeWindow({});
 ```
 
-## AMD use
 
-Configure the `can` and `jquery` paths and the `can-vdom` package:
+1. __global__ <code>{[window](#window-object)}</code>:
+  An object that represents the environment's global.
 
-```html
-<script src="require.js"></script>
-<script>
-	require.config({
-	    paths: {
-	        "jquery": "node_modules/jquery/dist/jquery",
-	        "can": "node_modules/canjs/dist/amd/can"
-	    },
-	    packages: [{
-		    	name: 'can-vdom',
-		    	location: 'node_modules/can-vdom/dist/amd',
-		    	main: 'lib/can-vdom'
-	    }]
-	});
-	require(["main-amd"], function(){});
-</script>
-```
+### <code>__can-vdom/make-document/make-document__ function</code>
 
-### Standalone use
+Exports a function that when called, returns a dom-light document object.
 
-Load the `global` version of the plugin:
 
-```html
-<script src='./node_modules/can-vdom/dist/global/can-vdom.js'></script>
-```
+#### <code>makeDocument()</code>
 
+
+Creates a new simple document using [can-simple-dom]. Provides light-weight document needs, mostly for server-side rendering.
+
+
+- __returns__ <code>{can-simple-dom/document/document}</code>:
+  A can-simple-dom document.
+  
+  
+### window `{Object}`
+
+
+An object representing a fake `window` object.
+
+
+
+#### <code>Object</code>
+
+- __document__ <code>{can-simple-dom/document/document}</code>:
+  A browser document
+  
+- __window__ <code>{Object}</code>:
+  The window itself.
+  
+- __self__ <code>{Object}</code>:
+  The `self` object is an alias for `window`.
+  
+- __addEventListener__ <code>{function}</code>:
+  A stub for `window.addEventListener`, does not actually set up events unless overridden some place else.
+  
+- __removeEventListener__ <code>{function}</code>:
+  A stub for `window.removeEventListener`.
+  
+- __navigator__ <code>{Object}</code>:
+  
+  
+- __location__ <code>{Object}</code>:
+  
+  
+- __history__ <code>{Object}</code>:
+  
+  
 ## Contributing
 
 ### Making a Build

--- a/can-vdom.md
+++ b/can-vdom.md
@@ -1,5 +1,43 @@
-@page can-vdom
+@module {{}} can-vdom
+@parent can-ecosystem
+@group can-vdom.modules modules
+@group can-vdom.types types
+@description
 
-# can-vdom
+A browser-lite environment for Node.js.
 
-A browser-lite environment for nodejs
+```js
+require("can-vdom");
+
+window === global; // true
+
+document.getElementsByTagName("body"); // [HTMLBodyElement]
+```
+
+@body
+
+**can-vdom** is what enables CanJS apps to run in the server. It provides a lite weight browser-like environment with a `document` and `window`. This allows code written for the browser, without extreme requirements, to also run on the server.
+
+# Shiming a browser environment
+
+Importing can-vdom will shim a browser-like environment into Node's globals. Use this approach to run code that expects a global `window` and/or `document` object.
+
+```js
+require("can-vdom");
+
+typeof window; // "object"
+
+typeof window.addEventListener; // "function"
+
+document.getElementById("foo"); // undefined
+```
+
+# Loading as a module
+
+If you want to prevent setting globals you can load `can-vdom/make-window/make-window` directly:
+
+```js
+var makeWindow = require("can-vdom/make-window/make-window");
+
+var myWindow = makeWindow(global);
+```

--- a/docs/apis.json
+++ b/docs/apis.json
@@ -1,0 +1,11 @@
+[
+	{"can-vdom": [
+		{"modules": [
+			"can-vdom/make-window/make-window",
+			"can-vdom/make-document/make-document"
+		]},
+		{"types": [
+			"can-vdom.types.window"
+		]}
+	]}
+]

--- a/docs/window.md
+++ b/docs/window.md
@@ -1,0 +1,20 @@
+@typedef {{}} can-vdom.types.window window
+@parent can-vdom.types
+
+An object representing a fake `window` object.
+
+@option {can-simple-dom/document/document} document A browser document
+
+@option {Object} window The window itself.
+
+@option {Object} self The `self` object is an alias for `window`.
+
+@option {function} addEventListener A stub for `window.addEventListener`, does not actually set up events unless overridden some place else.
+
+@option {function} removeEventListener A stub for `window.removeEventListener`.
+
+@option {Object} navigator
+
+@option {Object} location
+
+@option {Object} history

--- a/make-document/make-document.js
+++ b/make-document/make-document.js
@@ -1,7 +1,15 @@
 /**
- * @function {function} can-vdom/make-document/
+ * @module {function} can-vdom/make-document/make-document ./make-document/make-document
+ * @parent can-vdom.modules
  *
  * Exports a function that when called, returns a dom-light document object.
+ *
+ * @signature `makeDocument()`
+ *
+ * Creates a new simple document using [can-simple-dom]. Provides light-weight document needs, mostly for server-side rendering.
+ *
+ * @return {can-simple-dom/document/document} A can-simple-dom document.
+ *
  */
 var simpleDOM = require("can-simple-dom");
 var makeParser = require("../make-parser/make-parser");

--- a/make-window/make-window.js
+++ b/make-window/make-window.js
@@ -1,3 +1,29 @@
+/**
+ * @module {function} can-vdom/make-window/make-window ./make-window/make-window
+ * @parent can-vdom.modules
+ *
+ * Exports a function that window called, returns an object that looks like a `window`.
+ *
+ * @signature `makeWindow()`
+ *
+ * Creates a document and places it, along with other common browser globals, on a new object and then returns that object.
+ *
+ * @return {can-vdom.types.window} An object with common browser globals.
+ *
+ * @signature `makeWindow(global)`
+ *
+ * Creates a document and places it, along with other common browser globals, on the `global` object.
+ *
+ * ```js
+ * var makeWindow = require("can-vdom/make-window/make-window");
+ *
+ * var window = makeWindow({});
+ * ```
+ *
+ * @param {can-vdom.types.window} global An object that represents the environment's global.
+ * @return The `global` provided as the argument.
+ */
+
 var makeDocument = require("../make-document/make-document");
 
 var noop = function(){};

--- a/package.json
+++ b/package.json
@@ -26,36 +26,16 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
     "build": "node build.js",
-    "document": "documentjs",
+    "document": "bit-docs",
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "can-vdom.js",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "donejs",
     "canjs"
   ],
   "system": {
     "main": "can-vdom",
-    "configDependencies": [
-      "live-reload"
-    ],
-    "npmIgnore": [
-      "documentjs",
-      "testee",
-      "generator-donejs",
-      "donejs-cli",
-      "steal-tools"
-    ],
     "npmAlgorithm": "flat",
     "map": {
       "./assert": "chai/chai"
@@ -73,9 +53,8 @@
     "can-view-parser": "^3.0.0-pre.2"
   },
   "devDependencies": {
-    "documentjs": "^0.4.2",
+    "bit-docs": "0.0.7",
     "jshint": "^2.9.1",
-    "cssify": "^0.6.0",
     "steal": "^0.16.0",
     "steal-tools": "^0.16.0",
     "testee": "^0.2.4",
@@ -85,5 +64,21 @@
     "chai": "^3.4.1",
     "mocha": "^2.3.4",
     "steal-mocha": "0.0.3"
+  },
+  "bit-docs": {
+    "dependencies": {
+      "bit-docs-glob-finder": "^0.0.5",
+      "bit-docs-dev": "^0.0.3",
+      "bit-docs-js": "^0.0.3",
+      "bit-docs-generate-readme": "^0.0.8"
+    },
+    "glob": {
+      "pattern": "**/*.{js,md}",
+      "ignore": "node_modules/**/*"
+    },
+    "readme": {
+      "apis": "./docs/apis.json"
+    },
+    "parent": "can-vdom"
   }
 }


### PR DESCRIPTION
This adds all of the documentation for the APIs this module provides.
Adds it to can-ecosystem for use in the greater site.

Closes #4
