### PR TITLE
Landscaper: Remove deprecated can-util methods and replace with can-globals

### DIFF
--- a/can-vdom.js
+++ b/can-vdom.js
@@ -2,7 +2,7 @@ var assign = require("can-util/js/assign/assign");
 var makeWindow = require("./make-window/make-window");
 
 var GLOBAL = require("can-util/js/global/global");
-var DOCUMENT = require("can-util/dom/document/document");
+var DOCUMENT = require("can-globals/document/document");
 
 var global = GLOBAL();
 assign(global, makeWindow(global));

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "dependencies": {
     "can-simple-dom": "^1.1.0",
     "can-util": "^3.9.0",
-    "can-view-parser": "^3.4.0"
+    "can-view-parser": "^3.4.0",
+    "can-globals": "^0.1.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.github.com/imaustink/d1faff15b89df8fb7964c5d5c3945e72**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.