### PR TITLE
Hide docs that can’t show up in the navigation

### DIFF
--- a/make-parser/make-parser.js
+++ b/make-parser/make-parser.js
@@ -1,5 +1,6 @@
 /**
  * @module {function} can-vdom/make-parser/
+ * @hide
  *
  * Returns a function that can generate a HTML->TOKENs parser
  * given a document.


### PR DESCRIPTION
Should these docs be included?

Part of https://github.com/canjs/canjs/issues/3660