### PR TITLE
upgrading to 4.0 dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-vdom",
-  "version": "3.2.5",
+  "version": "4.0.0-pre.0",
   "description": "A browser-lite environment for nodejs",
   "homepage": "http://canjs.com",
   "repository": {
@@ -51,9 +51,9 @@
   },
   "dependencies": {
     "can-assign": "^1.0.0",
-    "can-globals": "<2.0.0",
+    "can-globals": "^1.0.0",
     "can-simple-dom": "^1.1.0",
-    "can-view-parser": "^3.5.1"
+    "can-view-parser": "^4.0.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",


### PR DESCRIPTION
Needed to upgrade because `can-view-parser` went 4.0.

> `can-view-parser` had to go 4.0 to drop some features allowing a `can-parse` version.