### PR TITLE
Add a warning when FormData is used

### DIFF
--- a/make-window/make-window.js
+++ b/make-window/make-window.js
@@ -34,8 +34,27 @@
 
 var makeDocument = require("../make-document/make-document");
 var simpleDOM = require("can-simple-dom");
+var devLog = require("can-log/dev/dev");
 
 var noop = function(){};
+
+function warnOnAccess(global, property) {
+	var hasWarned = false;
+	var value = global[property];
+	Object.defineProperty(global, property, {
+		get: function(){
+			if(!hasWarned) {
+				hasWarned = true;
+				devLog.warn("The global " + property + " is not supported by can-vdom.");
+			}
+
+			return value;
+		},
+		set: function(newValue) {
+			value = newValue;
+		}
+	})
+}
 
 module.exports = function(global){
 	global = global || {};
@@ -69,5 +88,9 @@ module.exports = function(global){
 	global.getComputedStyle = function (node) {
 		return node.style;
 	};
+
+	// Unsupported properties
+	warnOnAccess(global, "FormData");
+
 	return global;
 };

--- a/package.json
+++ b/package.json
@@ -52,11 +52,13 @@
   "dependencies": {
     "can-assign": "^1.0.0",
     "can-globals": "^1.0.0",
+    "can-log": "^1.0.0",
     "can-simple-dom": "^1.1.0",
     "can-view-parser": "^4.0.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",
+    "can-test-helpers": "^1.1.2",
     "can-util": "^3.9.0",
     "chai": "^4.1.2",
     "detect-cyclic-packages": "^1.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var assert = require("assert");
 var isNode = typeof process !== "undefined" && {}.toString.call(process) === "[object process]";
 var makeDocument = require("../make-document/make-document");
+var devHelpers = require("can-test-helpers/lib/dev");
 
 var childNodes = require("can-util/dom/child-nodes/child-nodes");
 
@@ -51,6 +52,15 @@ if(isNode) {
 		it("Node exposes the nodeType constants", function(){
 			assert.equal(window.Node.ELEMENT_NODE, 1, "has the element nodeType");
 			assert.equal(window.Node.TEXT_NODE, 3, "has the text nodeType");
+		});
+
+		it("Warns when using non-supported fields", function(){
+			var undo = devHelpers.willWarn(/not supported/);
+
+			// Access FormData
+			window.FormData;
+
+			assert.equal(undo(), 1, "Warned one time");
 		});
 	});
 }


### PR DESCRIPTION
FormData is not supported by can-vdom, so warn when someone attempts to
access it.